### PR TITLE
3.1に含むスニペットの追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ public object Hoge
 
 //------------------------------------------------------------------------------------//
 /// <summary>HogePropertyの値が変わった時のコールバック関数</summary>
-/// 
+///
 /// <param name="d">依存関係プロパティのインスタンスがあるクラス（キャストして使用）</param>
 /// <param name="e">イベントの情報</param>
 //! @author ELIONIX
@@ -175,6 +175,74 @@ protected static void OnHogePropertyChanged(DependencyObject d, DependencyProper
 |名前|Hoge|プロパティ名を決定する。|
 |初期値|default|プロパティの初期値を決定する。|
 |親クラス|Piyo|依存関係プロパティを持つクラスの型。<br>実際にはPiyoでは無く雛形を生成したクラスの名前が自動的に入る。|
+|author|ELIONIX|自分の名前を記述する|
+
+また、コードの生成と同時に、"System.Windows"のusing宣言と、WindowsBase.dllの参照が追加される。
+
+#### propae, propaeb
+
+添付プロパティと添付ビヘイビアの定義を記述するときに使用するスニペットとなる。
+
+- proppe
+- proppeb
+
+の二つが存在する。  
+また、標準にpropaというスニペットが存在し、それを改良したものとなる。  
+名称もpropaから派生し、PROPA Elionix (Behavior)である。  
+元のpropdpのpropはPROPerty、aはAttachedと思われる。
+
+propaeは以下の雛形を生成する
+
+```cs
+/// <summary>このプロパティは何か？</summary>
+public static readonly DependencyProperty HogeProperty = DependencyProperty.RegisterAttached(
+	"Hoge",
+	typeof(object),
+	typeof(Piyo),
+	new PropertyMetadata(default));
+
+/// <summary>Hoge添付プロパティのgetter</summary>
+public static object GetHoge(DependencyObject obj) => (object)obj.GetValue(HogeProperty);
+/// <summary>Hoge添付プロパティのsetter</summary>
+public static void SetHoge(DependencyObject obj, object value) => obj.SetValue(HogeProperty, value);
+```
+
+また、propaebは以下の雛形を生成する
+
+```cs
+/// <summary>このプロパティは何か？</summary>
+public static readonly DependencyProperty HogeProperty = DependencyProperty.RegisterAttached(
+	"Hoge",
+	typeof(object),
+	typeof(Piyo),
+	new PropertyMetadata(default, new PropertyChangedCallback(OnHogePropertyChanged)));
+
+/// <summary>Hoge添付プロパティのgetter</summary>
+public static object GetHoge(DependencyObject obj) => (object)obj.GetValue(HogeProperty);
+/// <summary>Hoge添付プロパティのsetter</summary>
+public static void SetHoge(DependencyObject obj, object value) => obj.SetValue(HogeProperty, value);
+
+//------------------------------------------------------------------------------------//
+/// <summary>HogePropertyの値が変わった時のコールバック関数（添付ビヘイビア動作）</summary>
+///
+/// <param name="d">添付プロパティを添付されたオブジェクト（キャストして使用）</param>
+/// <param name="e">イベントの情報</param>
+//! @author ELIONIX
+//------------------------------------------------------------------------------------//
+protected static void OnHogePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+{
+}
+```
+
+この雛形において、変更出来る箇所は以下の通り。
+
+|箇所|初期文字列|説明|
+|:--|:--|:--|
+|summary文|このプロパティは何か？|プロパティの説明文を記述する。|
+|型|object|プロパティの型を決定する。|
+|名前|Hoge|プロパティ名を決定する。|
+|初期値|default|プロパティの初期値を決定する。|
+|対象クラス|Piyo|添付プロパティを添付するクラスの型。|
 |author|ELIONIX|自分の名前を記述する|
 
 また、コードの生成と同時に、"System.Windows"のusing宣言と、WindowsBase.dllの参照が追加される。

--- a/README.md
+++ b/README.md
@@ -58,6 +58,49 @@ Lib.BindableBaseやLib.Data.CloneableDataBaseの派生クラスなど、シリ�
 
 ### classの初期化・終了系
 
+#### vmctorwpf
+
+WPFのプロジェクトにおける、標準的なコンストラクタの記述の雛形を生成する。  
+
+以下の雛形が生成される。
+
+```cs
+//------------------------------------------------------------------------------------//
+/// <summary>xamlデザイナ用のインスタンスを生成</summary>
+///
+//! @author ELIONIX
+//------------------------------------------------------------------------------------//
+public HogeViewModel()
+	: this(null, null)
+{
+	ViewModelUtility.InitializeForXamlDesigner(() => { });
+}
+
+//------------------------------------------------------------------------------------//
+/// <summary>Modelを注入してインスタンスを生成</summary>
+///
+/// <param name="container">モデル格納オブジェクト</param>
+/// <param name="uiActions">UIに依存する処理を中継するオブジェクト</param>
+//! @author ELIONIX
+//------------------------------------------------------------------------------------//
+public HogeViewModel(
+	Models.IModelContainer container,
+	IWpfUiActions uiActions)
+	: base(container, uiActions)
+{
+}
+```
+
+この雛形において、変更出来る箇所は以下の通り。
+
+|箇所|初期文字列|説明|
+|:--|:--|:--|
+|author|ELIONIX|自分の名前を記述する|
+|model container|Models.IModelContainer|modelを格納するオブジェクトの型を決定する。|
+|関数名|HogeVilewModel|コンストラクタ。<br>実際にはHogeViewModelでは無く雛形を生成したクラスの名前が自動的に入る。|
+
+また、コードの生成と同時に、"ELIONIX.Lib.Wpf"のusing宣言と、ELIONIX.Lib.Wpf.dllの参照が追加される。
+
 #### disposablebor
 
 DisposableBaseを継承したクラスにおいてoverrideして実装しなくてはいけない、DisposeManagedResourcesとDisposeUnmanagedResources関数の雛形を生成する。  

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 ## C#のLib用のスニペット
 
-### BindableBase補助
+### データクラス関連
+
+#### propbb
 
 Lib.BindableBaseやその派生クラスを継承して作成するクラスにおいて、変更通知プロパティの定義を記述するときに使用するスニペットとなる。  
 以下の２つが存在する。
@@ -36,3 +38,18 @@ public object Hoge
 - クラス型（デフォルトだとobjectになっている部分）
 - プロパティ名（Hogeの部分。backing field側のアンダースコアは固定）
 - プロパティの初期値（defaultの部分）
+
+#### dcattr
+
+Lib.BindableBaseやLib.Data.CloneableDataBaseの派生クラスなど、シリアライズ対象となるクラスにはDataContract属性やSerializable属性を付ける。  
+その記述を補助するスニペットとなる。  
+名前は、Data Contract ATTRibuteである。
+
+以下のコードが生成される。
+
+```cs
+[Serializable]
+[DataContract(Namespace = "")]
+```
+
+同時に、"System.Runtime.Serialization"のusing宣言と、System.Runtime.Serialization.dllの参照が追加される。

--- a/README.md
+++ b/README.md
@@ -53,3 +53,50 @@ Lib.BindableBaseやLib.Data.CloneableDataBaseの派生クラスなど、シリ�
 ```
 
 同時に、"System.Runtime.Serialization"のusing宣言と、System.Runtime.Serialization.dllの参照が追加される。
+
+### その他
+
+#### disposablebor
+
+DisposableBaseを継承したクラスにおいてoverrideして実装しなくてはいけない、DisposeManagedResourcesとDisposeUnmanagedResources関数の雛形を生成する。  
+名前は、DISPOSABLE Base OverRideである。
+
+以下のコードが生成される。
+
+```cs
+//------------------------------------------------------------------------------------//
+/// <summary>マネージドリソースを破棄する</summary>
+///
+/// <remarks>
+/// Disposableな内部オブジェクトはこっちの関数で解放する。
+/// また、この関数をoverrideする時、
+/// 抽象でない基底クラスの同関数を必ず呼ぶようにすること。
+/// </remarks>
+//! @author ELIONIX
+//------------------------------------------------------------------------------------//
+protected override void DisposeManagedResources()
+{
+	//何も無し
+}
+
+//------------------------------------------------------------------------------------//
+/// <summary>アンマネージドリソースを破棄する</summary>
+///
+/// <remarks>
+/// 通常こちらの関数で解放するべきリソースは殆ど無い。
+/// ファイルやウィンドウなどでも、Manageクラスでラップされていれば
+/// ManagedResourceとして処理する（Disposeを呼ぶ）。
+/// ここに書くのは、Win32 APIを直接呼んで取得したハンドル（IntPtr）等を
+/// CloseHandleする必要があるような場合である。
+/// また、この関数をoverrideする時、
+/// 抽象でない基底クラスの同関数を必ず呼ぶようにすること。
+/// </remarks>
+//! @author ELIONIX
+//------------------------------------------------------------------------------------//
+protected override void DisposeUnmanagedResources()
+{
+	//何も無し
+}
+```
+
+この雛形において、@authorの名前部分が変更出来る部分となる。

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ### データクラス関連
 
-#### propbb
+#### propbb, propbbd
 
 Lib.BindableBaseやその派生クラスを継承して作成するクラスにおいて、変更通知プロパティの定義を記述するときに使用するスニペットとなる。  
 以下の２つが存在する。
@@ -32,12 +32,14 @@ public object Hoge
 }
 ```
 
-この雛形において、以下の４つが変更出来る部分である。
+この雛形において、変更出来る箇所は以下の通り。
 
-- summary文（ただし(backing field)の部分は固定）
-- クラス型（デフォルトだとobjectになっている部分）
-- プロパティ名（Hogeの部分。backing field側のアンダースコアは固定）
-- プロパティの初期値（defaultの部分）
+|箇所|初期文字列|説明|
+|:--|:--|:--|
+|summary文|Hoge's description|プロパティの説明文を記述する。|
+|型|object|プロパティの型を決定する。|
+|名前|Hoge|プロパティ名を決定する。|
+|初期値|default|プロパティの初期値を決定する。|
 
 #### dcattr
 
@@ -52,9 +54,9 @@ Lib.BindableBaseやLib.Data.CloneableDataBaseの派生クラスなど、シリ�
 [DataContract(Namespace = "")]
 ```
 
-同時に、"System.Runtime.Serialization"のusing宣言と、System.Runtime.Serialization.dllの参照が追加される。
+また、コードの生成と同時に、"System.Runtime.Serialization"のusing宣言と、System.Runtime.Serialization.dllの参照が追加される。
 
-### その他
+### classの初期化・終了系
 
 #### disposablebor
 
@@ -99,4 +101,80 @@ protected override void DisposeUnmanagedResources()
 }
 ```
 
-この雛形において、@authorの名前部分が変更出来る部分となる。
+|箇所|初期文字列|説明|
+|:--|:--|:--|
+|author|ELIONIX|自分の名前を記述する|
+
+### WPF関連
+
+#### propdpe, propdpec
+
+依存関係プロパティの定義を記述するときに使用するスニペットとなる。
+
+- propdpe
+- propdpec
+
+の二つが存在する。  
+また、標準にpropdpというスニペットが存在し、それを改良したものとなる。  
+名称もpropdpから派生し、PROPDP Elionix (Callback)である。  
+元のpropdpのpropはPROPerty、dpはDependency Propertyと思われる。
+
+propdpeは以下の雛形を生成する
+
+```cs
+/// <summary>このプロパティは何か？</summary>
+public static readonly DependencyProperty HogeProperty = DependencyProperty.Register(
+	nameof(Hoge),
+	typeof(object),
+	typeof(Piyo),
+	new PropertyMetadata(default));
+
+/// <summary>Hoge依存関係プロパティのラッパー</summary>
+public object Hoge
+{
+	get => (object)GetValue(HogeProperty);
+	set => SetValue(HogeProperty, value);
+}
+```
+
+また、propdpecは以下の雛形を生成する
+
+```cs
+/// <summary>このプロパティは何か？</summary>
+public static readonly DependencyProperty HogeProperty = DependencyProperty.Register(
+	nameof(Hoge),
+	typeof(object),
+	typeof(Piyo),
+	new PropertyMetadata(default, new PropertyChangedCallback(OnHogePropertyChanged)));
+
+/// <summary>Hoge依存関係プロパティのラッパー</summary>
+public object Hoge
+{
+	get => (object)GetValue(HogeProperty);
+	set => SetValue(HogeProperty, value);
+}
+
+//------------------------------------------------------------------------------------//
+/// <summary>HogePropertyの値が変わった時のコールバック関数</summary>
+/// 
+/// <param name="d">依存関係プロパティのインスタンスがあるクラス（キャストして使用）</param>
+/// <param name="e">イベントの情報</param>
+//! @author ELIONIX
+//------------------------------------------------------------------------------------//
+protected static void OnHogePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+{
+}
+```
+
+この雛形において、変更出来る箇所は以下の通り。
+
+|箇所|初期文字列|説明|
+|:--|:--|:--|
+|summary文|このプロパティは何か？|プロパティの説明文を記述する。|
+|型|object|プロパティの型を決定する。|
+|名前|Hoge|プロパティ名を決定する。|
+|初期値|default|プロパティの初期値を決定する。|
+|親クラス|Piyo|依存関係プロパティを持つクラスの型。<br>実際にはPiyoでは無く雛形を生成したクラスの名前が自動的に入る。|
+|author|ELIONIX|自分の名前を記述する|
+
+また、コードの生成と同時に、"System.Windows"のusing宣言と、WindowsBase.dllの参照が追加される。

--- a/projects/LibSnippet/LibSnippet.csproj
+++ b/projects/LibSnippet/LibSnippet.csproj
@@ -93,6 +93,10 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
+    <Content Include="Snippets\CSharp\ELIONIX.Lib\vmctorwpf.snippet">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>

--- a/projects/LibSnippet/LibSnippet.csproj
+++ b/projects/LibSnippet/LibSnippet.csproj
@@ -85,6 +85,14 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
+    <Content Include="Snippets\CSharp\ELIONIX.Lib\propae.snippet">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
+    <Content Include="Snippets\CSharp\ELIONIX.Lib\propaeb.snippet">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>

--- a/projects/LibSnippet/LibSnippet.csproj
+++ b/projects/LibSnippet/LibSnippet.csproj
@@ -77,6 +77,14 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
+    <Content Include="Snippets\CSharp\ELIONIX.Lib\propdpe.snippet">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
+    <Content Include="Snippets\CSharp\ELIONIX.Lib\propdpec.snippet">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>

--- a/projects/LibSnippet/LibSnippet.csproj
+++ b/projects/LibSnippet/LibSnippet.csproj
@@ -69,6 +69,10 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
+    <Content Include="Snippets\CSharp\ELIONIX.Lib\dcattr.snippet">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>

--- a/projects/LibSnippet/LibSnippet.csproj
+++ b/projects/LibSnippet/LibSnippet.csproj
@@ -61,6 +61,10 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
+    <Content Include="Snippets\CSharp\ELIONIX.Lib\disposablebor.snippet">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
     <Content Include="Snippets\CSharp\ELIONIX.Lib\propbb.snippet">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>

--- a/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/dcattr.snippet
+++ b/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/dcattr.snippet
@@ -4,7 +4,7 @@
     <Header>
       <Title>dcattr</Title>
       <Shortcut>dcattr</Shortcut>
-      <Description>Generate DataContext attribute and Serializable attribute.</Description>
+      <Description>DataContext属性とSerializable属性を生成する。</Description>
       <Author>SAITO Takamasa</Author>
       <SnippetTypes>
         <SnippetType>Expansion</SnippetType>

--- a/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/dcattr.snippet
+++ b/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/dcattr.snippet
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<CodeSnippets xmlns="http://schemas.microsoft.com/VisualStudio/2005/CodeSnippet">
+  <CodeSnippet Format="1.0.0">
+    <Header>
+      <Title>dcattr</Title>
+      <Shortcut>dcattr</Shortcut>
+      <Description>Generate DataContext attribute and Serializable attribute.</Description>
+      <Author>SAITO Takamasa</Author>
+      <SnippetTypes>
+        <SnippetType>Expansion</SnippetType>
+      </SnippetTypes>
+    </Header>
+    <Snippet>
+      <References>
+        <Reference>
+          <Assembly>System.Runtime.Serialization.dll</Assembly>
+        </Reference>
+      </References>
+      <Imports>
+        <Import>
+          <Namespace>System.Runtime.Serialization</Namespace>
+        </Import>
+      </Imports>
+      <Code Language="csharp">
+        <![CDATA[[Serializable]
+	[DataContract(Namespace = "")]$end$]]>
+      </Code>
+    </Snippet>
+  </CodeSnippet>
+</CodeSnippets>

--- a/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/disposablebor.snippet
+++ b/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/disposablebor.snippet
@@ -52,7 +52,7 @@
 		{
 			//何も無し
 		}
-    $end$]]>
+		$end$]]>
       </Code>
     </Snippet>
   </CodeSnippet>

--- a/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/disposablebor.snippet
+++ b/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/disposablebor.snippet
@@ -4,7 +4,7 @@
     <Header>
       <Title>disposablebor</Title>
       <Shortcut>disposablebor</Shortcut>
-      <Description>Generate DisposeManagedResources and DisposeUnmanagedResources of DisposableBase override definition.</Description>
+      <Description>DisposableBaseのDisposeManagedResources関数とDisposeUnmanagedResourcesのoverride定義を生成する。</Description>
       <Author>SAITO Takamasa</Author>
       <SnippetTypes>
         <SnippetType>Expansion</SnippetType>
@@ -14,7 +14,7 @@
       <Declarations>
         <Literal>
           <ID>author</ID>
-          <ToolTip>Your name</ToolTip>
+          <ToolTip>作成者の名前</ToolTip>
           <Default>ELIONIX</Default>
         </Literal>
       </Declarations>

--- a/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/disposablebor.snippet
+++ b/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/disposablebor.snippet
@@ -1,0 +1,59 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<CodeSnippets xmlns="http://schemas.microsoft.com/VisualStudio/2005/CodeSnippet">
+  <CodeSnippet Format="1.0.0">
+    <Header>
+      <Title>disposablebor</Title>
+      <Shortcut>disposablebor</Shortcut>
+      <Description>Generate DisposeManagedResources and DisposeUnmanagedResources of DisposableBase override definition.</Description>
+      <Author>SAITO Takamasa</Author>
+      <SnippetTypes>
+        <SnippetType>Expansion</SnippetType>
+      </SnippetTypes>
+    </Header>
+    <Snippet>
+      <Declarations>
+        <Literal>
+          <ID>author</ID>
+          <ToolTip>Your name</ToolTip>
+          <Default>ELIONIX</Default>
+        </Literal>
+      </Declarations>
+      <Code Language="csharp">
+        <![CDATA[//------------------------------------------------------------------------------------//
+		/// <summary>マネージドリソースを破棄する</summary>
+		///
+		/// <remarks>
+		/// Disposableな内部オブジェクトはこっちの関数で解放する。
+		/// また、この関数をoverrideする時、
+		/// 抽象でない基底クラスの同関数を必ず呼ぶようにすること。
+		/// </remarks>
+		//! @author $author$
+		//------------------------------------------------------------------------------------//
+		protected override void DisposeManagedResources()
+		{
+			//何も無し
+		}
+
+		//------------------------------------------------------------------------------------//
+		/// <summary>アンマネージドリソースを破棄する</summary>
+		///
+		/// <remarks>
+		/// 通常こちらの関数で解放するべきリソースは殆ど無い。
+		/// ファイルやウィンドウなどでも、Manageクラスでラップされていれば
+		/// ManagedResourceとして処理する（Disposeを呼ぶ）。
+		/// ここに書くのは、Win32 APIを直接呼んで取得したハンドル（IntPtr）等を
+		/// CloseHandleする必要があるような場合である。
+		/// また、この関数をoverrideする時、
+		/// 抽象でない基底クラスの同関数を必ず呼ぶようにすること。
+		/// </remarks>
+		//! @author $author$
+		//------------------------------------------------------------------------------------//
+		protected override void DisposeUnmanagedResources()
+		{
+			//何も無し
+		}
+    $end$]]>
+      </Code>
+    </Snippet>
+  </CodeSnippet>
+</CodeSnippets>

--- a/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/propae.snippet
+++ b/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/propae.snippet
@@ -1,0 +1,67 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<CodeSnippets xmlns="http://schemas.microsoft.com/VisualStudio/2005/CodeSnippet">
+  <CodeSnippet Format="1.0.0">
+    <Header>
+      <Title>propae</Title>
+      <Shortcut>propae</Shortcut>
+      <Description>添付プロパティを生成する。</Description>
+      <Author>SAITO Takamasa</Author>
+      <SnippetTypes>
+        <SnippetType>Expansion</SnippetType>
+      </SnippetTypes>
+    </Header>
+    <Snippet>
+      <References>
+        <Reference>
+          <Assembly>WindowsBase.dll</Assembly>
+        </Reference>
+      </References>
+      <Imports>
+        <Import>
+          <Namespace>System.Windows</Namespace>
+        </Import>
+      </Imports>
+      <Declarations>
+        <Literal>
+          <ID>type</ID>
+          <ToolTip>プロパティの型</ToolTip>
+          <Default>object</Default>
+        </Literal>
+        <Literal>
+          <ID>property</ID>
+          <ToolTip>プロパティ名</ToolTip>
+          <Default>Hoge</Default>
+        </Literal>
+        <Literal>
+          <ID>summary</ID>
+          <ToolTip>プロパティの説明</ToolTip>
+          <Default>このプロパティは何か？</Default>
+        </Literal>
+        <Literal>
+          <ID>initial</ID>
+          <ToolTip>プロパティの初期値</ToolTip>
+          <Default>default</Default>
+        </Literal>
+        <Literal>
+          <ID>target</ID>
+          <ToolTip>プロパティを添付する対象のクラス型</ToolTip>
+          <Default>Piyo</Default>
+        </Literal>
+      </Declarations>
+      <Code Language="csharp">
+        <![CDATA[/// <summary>$summary$</summary>
+		public static readonly DependencyProperty $property$Property = DependencyProperty.RegisterAttached(
+			"$property$",
+			typeof($type$),
+			typeof($target$),
+			new PropertyMetadata($initial$));
+
+		/// <summary>$property$添付プロパティのgetter</summary>
+		public static $type$ Get$property$(DependencyObject obj) => ($type$)obj.GetValue($property$Property);
+		/// <summary>$property$添付プロパティのsetter</summary>
+		public static void Set$property$(DependencyObject obj, $type$ value) => obj.SetValue($property$Property, value);
+    $end$]]>
+      </Code>
+    </Snippet>
+  </CodeSnippet>
+</CodeSnippets>

--- a/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/propae.snippet
+++ b/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/propae.snippet
@@ -60,7 +60,7 @@
 		public static $type$ Get$property$(DependencyObject obj) => ($type$)obj.GetValue($property$Property);
 		/// <summary>$property$添付プロパティのsetter</summary>
 		public static void Set$property$(DependencyObject obj, $type$ value) => obj.SetValue($property$Property, value);
-    $end$]]>
+		$end$]]>
       </Code>
     </Snippet>
   </CodeSnippet>

--- a/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/propaeb.snippet
+++ b/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/propaeb.snippet
@@ -2,9 +2,9 @@
 <CodeSnippets xmlns="http://schemas.microsoft.com/VisualStudio/2005/CodeSnippet">
   <CodeSnippet Format="1.0.0">
     <Header>
-      <Title>propdpec</Title>
-      <Shortcut>propdpec</Shortcut>
-      <Description>依存関係プロパティを生成する。（コールバック関数付き）</Description>
+      <Title>propaeb</Title>
+      <Shortcut>propaeb</Shortcut>
+      <Description>添付ビヘイビア（コールバック付き添付プロパティ）を生成する。</Description>
       <Author>SAITO Takamasa</Author>
       <SnippetTypes>
         <SnippetType>Expansion</SnippetType>
@@ -43,10 +43,9 @@
           <Default>default</Default>
         </Literal>
         <Literal>
-          <ID>owner</ID>
-          <Function>ClassName()</Function>
-          <ToolTip>依存関係プロパティを持つクラスの名前</ToolTip>
-          <Default>ignore this element</Default>
+          <ID>target</ID>
+          <ToolTip>プロパティを添付する対象のクラス型</ToolTip>
+          <Default>Piyo</Default>
         </Literal>
         <Literal>
           <ID>author</ID>
@@ -56,23 +55,21 @@
       </Declarations>
       <Code Language="csharp">
         <![CDATA[/// <summary>$summary$</summary>
-		public static readonly DependencyProperty $property$Property = DependencyProperty.Register(
-			nameof($property$),
+		public static readonly DependencyProperty $property$Property = DependencyProperty.RegisterAttached(
+			"$property$",
 			typeof($type$),
-			typeof($owner$),
+			typeof($target$),
 			new PropertyMetadata($initial$, new PropertyChangedCallback(On$property$PropertyChanged)));
 
-		/// <summary>$property$依存関係プロパティのラッパー</summary>
-		public $type$ $property$
-		{
-			get => ($type$)GetValue($property$Property);
-			set => SetValue($property$Property, value);
-		}
-
+		/// <summary>$property$添付プロパティのgetter</summary>
+		public static $type$ Get$property$(DependencyObject obj) => ($type$)obj.GetValue($property$Property);
+		/// <summary>$property$添付プロパティのsetter</summary>
+		public static void Set$property$(DependencyObject obj, $type$ value) => obj.SetValue($property$Property, value);
+    
     //------------------------------------------------------------------------------------//
-		/// <summary>$property$Propertyの値が変わった時のコールバック関数</summary>
+		/// <summary>$property$Propertyの値が変わった時のコールバック関数（添付ビヘイビア動作）</summary>
 		///
-		/// <param name="d">依存関係プロパティのインスタンスがあるクラスのオブジェクト（キャストして使用）</param>
+		/// <param name="d">添付プロパティを添付されたオブジェクト（キャストして使用）</param>
 		/// <param name="e">イベントの情報</param>
 		//! @author $author$
 		//------------------------------------------------------------------------------------//

--- a/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/propaeb.snippet
+++ b/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/propaeb.snippet
@@ -76,7 +76,7 @@
 		protected static void On$property$PropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
 		{
 		}
-    $end$]]>
+		$end$]]>
       </Code>
     </Snippet>
   </CodeSnippet>

--- a/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/propbb.snippet
+++ b/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/propbb.snippet
@@ -42,7 +42,7 @@
       get { return _$property$; }
       set { SetProperty(ref _$property$, value); }
     }
-    $end$]]>
+		$end$]]>
       </Code>
     </Snippet>
   </CodeSnippet>

--- a/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/propbb.snippet
+++ b/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/propbb.snippet
@@ -4,7 +4,7 @@
     <Header>
       <Title>propbb</Title>
       <Shortcut>propbb</Shortcut>
-      <Description>Generate change notification properties for Lib.BindableBase.</Description>
+      <Description>Lib.BindableBase用の変更通知プロパティの定義を生成する。</Description>
       <Author>SAITO Takamasa</Author>
       <SnippetTypes>
         <SnippetType>Expansion</SnippetType>
@@ -14,22 +14,22 @@
       <Declarations>
         <Literal>
           <ID>type</ID>
-          <ToolTip>Type of property</ToolTip>
+          <ToolTip>プロパティの型</ToolTip>
           <Default>object</Default>
         </Literal>
         <Literal>
           <ID>property</ID>
-          <ToolTip>Name of property</ToolTip>
+          <ToolTip>プロパティ名</ToolTip>
           <Default>Hoge</Default>
         </Literal>
         <Literal>
           <ID>summary</ID>
-          <ToolTip>Description of property</ToolTip>
-          <Default>What is the Hoge parameter</Default>
+          <ToolTip>プロパティの説明</ToolTip>
+          <Default>このプロパティは何か？</Default>
         </Literal>
         <Literal>
           <ID>initial</ID>
-          <ToolTip>Initial value of property</ToolTip>
+          <ToolTip>プロパティの初期値</ToolTip>
           <Default>default</Default>
         </Literal>
       </Declarations>

--- a/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/propbbd.snippet
+++ b/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/propbbd.snippet
@@ -4,7 +4,7 @@
     <Header>
       <Title>propbbd</Title>
       <Shortcut>propbbd</Shortcut>
-      <Description>Generate change notification properties for Lib.BindableBase. (With DataMember)</Description>
+      <Description>Lib.BindableBase用の変更通知プロパティの定義を生成する。（DataMember属性付き）</Description>
       <Author>SAITO Takamasa</Author>
       <SnippetTypes>
         <SnippetType>Expansion</SnippetType>
@@ -14,22 +14,22 @@
       <Declarations>
         <Literal>
           <ID>type</ID>
-          <ToolTip>Type of property</ToolTip>
+          <ToolTip>プロパティの型</ToolTip>
           <Default>object</Default>
         </Literal>
         <Literal>
           <ID>property</ID>
-          <ToolTip>Name of property</ToolTip>
+          <ToolTip>プロパティ名</ToolTip>
           <Default>Hoge</Default>
         </Literal>
         <Literal>
           <ID>summary</ID>
-          <ToolTip>Description of property</ToolTip>
-          <Default>What is the Hoge parameter</Default>
+          <ToolTip>プロパティの説明</ToolTip>
+          <Default>このプロパティは何か？</Default>
         </Literal>
         <Literal>
           <ID>initial</ID>
-          <ToolTip>Initial value of property</ToolTip>
+          <ToolTip>プロパティの初期値</ToolTip>
           <Default>default</Default>
         </Literal>
       </Declarations>

--- a/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/propbbd.snippet
+++ b/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/propbbd.snippet
@@ -43,7 +43,7 @@
       get { return _$property$; }
       set { SetProperty(ref _$property$, value); }
     }
-    $end$]]>
+		$end$]]>
       </Code>
     </Snippet>
   </CodeSnippet>

--- a/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/propdpe.snippet
+++ b/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/propdpe.snippet
@@ -1,0 +1,70 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<CodeSnippets xmlns="http://schemas.microsoft.com/VisualStudio/2005/CodeSnippet">
+  <CodeSnippet Format="1.0.0">
+    <Header>
+      <Title>propdpe</Title>
+      <Shortcut>propdpe</Shortcut>
+      <Description>依存関係プロパティを生成する。</Description>
+      <Author>SAITO Takamasa</Author>
+      <SnippetTypes>
+        <SnippetType>Expansion</SnippetType>
+      </SnippetTypes>
+    </Header>
+    <Snippet>
+      <References>
+        <Reference>
+          <Assembly>WindowsBase.dll</Assembly>
+        </Reference>
+      </References>
+      <Imports>
+        <Import>
+          <Namespace>System.Windows</Namespace>
+        </Import>
+      </Imports>
+      <Declarations>
+        <Literal>
+          <ID>type</ID>
+          <ToolTip>プロパティの型</ToolTip>
+          <Default>object</Default>
+        </Literal>
+        <Literal>
+          <ID>property</ID>
+          <ToolTip>プロパティの名前</ToolTip>
+          <Default>Hoge</Default>
+        </Literal>
+        <Literal>
+          <ID>summary</ID>
+          <ToolTip>プロパティの説明</ToolTip>
+          <Default>このプロパティは何か？</Default>
+        </Literal>
+        <Literal>
+          <ID>initial</ID>
+          <ToolTip>プロパティの初期値</ToolTip>
+          <Default>default</Default>
+        </Literal>
+        <Literal>
+          <ID>owner</ID>
+          <Function>ClassName()</Function>
+          <ToolTip>依存関係プロパティを持つクラスの名前</ToolTip>
+          <Default>ignore this element</Default>
+        </Literal>
+      </Declarations>
+      <Code Language="csharp">
+        <![CDATA[/// <summary>$summary$</summary>
+		public static readonly DependencyProperty $property$Property = DependencyProperty.Register(
+			nameof($property$),
+			typeof($type$),
+			typeof($owner$),
+			new PropertyMetadata($initial$));
+
+		/// <summary>$property$依存関係プロパティのラッパー</summary>
+		public $type$ $property$
+		{
+			get => ($type$)GetValue($property$Property);
+			set => SetValue($property$Property, value);
+		}
+    $end$]]>
+      </Code>
+    </Snippet>
+  </CodeSnippet>
+</CodeSnippets>

--- a/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/propdpe.snippet
+++ b/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/propdpe.snippet
@@ -42,11 +42,10 @@
           <ToolTip>プロパティの初期値</ToolTip>
           <Default>default</Default>
         </Literal>
-        <Literal>
+        <Literal Editable="false">
           <ID>owner</ID>
           <Function>ClassName()</Function>
           <ToolTip>依存関係プロパティを持つクラスの名前</ToolTip>
-          <Default>ignore this element</Default>
         </Literal>
       </Declarations>
       <Code Language="csharp">
@@ -63,7 +62,7 @@
 			get => ($type$)GetValue($property$Property);
 			set => SetValue($property$Property, value);
 		}
-    $end$]]>
+		$end$]]>
       </Code>
     </Snippet>
   </CodeSnippet>

--- a/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/propdpe.snippet
+++ b/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/propdpe.snippet
@@ -29,7 +29,7 @@
         </Literal>
         <Literal>
           <ID>property</ID>
-          <ToolTip>プロパティの名前</ToolTip>
+          <ToolTip>プロパティ名</ToolTip>
           <Default>Hoge</Default>
         </Literal>
         <Literal>

--- a/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/propdpec.snippet
+++ b/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/propdpec.snippet
@@ -29,7 +29,7 @@
         </Literal>
         <Literal>
           <ID>property</ID>
-          <ToolTip>プロパティの名前</ToolTip>
+          <ToolTip>プロパティ名</ToolTip>
           <Default>Hoge</Default>
         </Literal>
         <Literal>

--- a/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/propdpec.snippet
+++ b/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/propdpec.snippet
@@ -1,0 +1,86 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<CodeSnippets xmlns="http://schemas.microsoft.com/VisualStudio/2005/CodeSnippet">
+  <CodeSnippet Format="1.0.0">
+    <Header>
+      <Title>propdpec</Title>
+      <Shortcut>propdpec</Shortcut>
+      <Description>依存関係プロパティを生成する。（コールバック関数付き）</Description>
+      <Author>SAITO Takamasa</Author>
+      <SnippetTypes>
+        <SnippetType>Expansion</SnippetType>
+      </SnippetTypes>
+    </Header>
+    <Snippet>
+      <References>
+        <Reference>
+          <Assembly>WindowsBase.dll</Assembly>
+        </Reference>
+      </References>
+      <Imports>
+        <Import>
+          <Namespace>System.Windows</Namespace>
+        </Import>
+      </Imports>
+      <Declarations>
+        <Literal>
+          <ID>type</ID>
+          <ToolTip>プロパティの型</ToolTip>
+          <Default>object</Default>
+        </Literal>
+        <Literal>
+          <ID>property</ID>
+          <ToolTip>プロパティの名前</ToolTip>
+          <Default>Hoge</Default>
+        </Literal>
+        <Literal>
+          <ID>summary</ID>
+          <ToolTip>プロパティの説明</ToolTip>
+          <Default>このプロパティは何か？</Default>
+        </Literal>
+        <Literal>
+          <ID>initial</ID>
+          <ToolTip>プロパティの初期値</ToolTip>
+          <Default>default</Default>
+        </Literal>
+        <Literal>
+          <ID>owner</ID>
+          <Function>ClassName()</Function>
+          <ToolTip>依存関係プロパティを持つクラスの名前</ToolTip>
+          <Default>ignore this element</Default>
+        </Literal>
+        <Literal>
+          <ID>author</ID>
+          <ToolTip>プロパティ作成者の名前</ToolTip>
+          <Default>ELIONIX</Default>
+        </Literal>
+      </Declarations>
+      <Code Language="csharp">
+        <![CDATA[/// <summary>$summary$</summary>
+		public static readonly DependencyProperty $property$Property = DependencyProperty.Register(
+			nameof($property$),
+			typeof($type$),
+			typeof($owner$),
+			new PropertyMetadata($initial$, new PropertyChangedCallback(On$property$PropertyChanged)));
+
+		/// <summary>$property$依存関係プロパティのラッパー</summary>
+		public $type$ $property$
+		{
+			get => ($type$)GetValue($property$Property);
+			set => SetValue($property$Property, value);
+		}
+    
+    //------------------------------------------------------------------------------------//
+		/// <summary>$property$Propertyの値が変わった時のコールバック関数</summary>
+		/// 
+		/// <param name="d">依存関係プロパティのインスタンスがあるクラス（キャストして使用）</param>
+		/// <param name="e">イベントの情報</param>
+		//! @author $author$
+		//------------------------------------------------------------------------------------//
+		protected static void On$property$PropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+		{
+		}
+    $end$]]>
+      </Code>
+    </Snippet>
+  </CodeSnippet>
+</CodeSnippets>

--- a/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/propdpec.snippet
+++ b/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/propdpec.snippet
@@ -42,11 +42,10 @@
           <ToolTip>プロパティの初期値</ToolTip>
           <Default>default</Default>
         </Literal>
-        <Literal>
+        <Literal Editable="false">
           <ID>owner</ID>
           <Function>ClassName()</Function>
           <ToolTip>依存関係プロパティを持つクラスの名前</ToolTip>
-          <Default>ignore this element</Default>
         </Literal>
         <Literal>
           <ID>author</ID>
@@ -79,7 +78,7 @@
 		protected static void On$property$PropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
 		{
 		}
-    $end$]]>
+		$end$]]>
       </Code>
     </Snippet>
   </CodeSnippet>

--- a/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/vmctorwpf.snippet
+++ b/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/vmctorwpf.snippet
@@ -1,0 +1,69 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<CodeSnippets xmlns="http://schemas.microsoft.com/VisualStudio/2005/CodeSnippet">
+  <CodeSnippet Format="1.0.0">
+    <Header>
+      <Title>vmctorwpf</Title>
+      <Shortcut>vmctorwpf</Shortcut>
+      <Description>View Modelのコンストラクタの雛形を生成する（WPF版）</Description>
+      <Author>SAITO Takamasa</Author>
+      <SnippetTypes>
+        <SnippetType>Expansion</SnippetType>
+      </SnippetTypes>
+    </Header>
+    <Snippet>
+      <References>
+        <Reference>
+          <Assembly>ELIONIX.Lib.Wpf.dll</Assembly>
+        </Reference>
+      </References>
+      <Imports>
+        <Import>
+          <Namespace>ELIONIX.Lib.Wpf</Namespace>
+        </Import>
+      </Imports>
+      <Declarations>
+        <Literal Editable="false">
+          <ID>class</ID>
+          <Function>ClassName()</Function>
+          <ToolTip>クラスの名前</ToolTip>
+        </Literal>
+        <Literal>
+          <ID>author</ID>
+          <ToolTip>作成者の名前</ToolTip>
+          <Default>ELIONIX</Default>
+        </Literal>
+        <Literal>
+          <ID>modelcontainer</ID>
+          <Default>Models.IModelContainer</Default>
+        </Literal>
+      </Declarations>
+      <Code Language="csharp" Kind="method decl">
+        <![CDATA[//------------------------------------------------------------------------------------//
+		/// <summary>xamlデザイナ用のインスタンスを生成</summary>
+		/// 
+		//! @author $author$
+		//------------------------------------------------------------------------------------//
+		public $class$()
+			: this(null, null)
+		{
+			ViewModelUtility.InitializeForXamlDesigner(() => { });
+		}
+
+		//------------------------------------------------------------------------------------//
+		/// <summary>Modelを注入してインスタンスを生成</summary>
+		/// 
+		/// <param name="container">モデル格納オブジェクト</param>
+		/// <param name="uiActions">UIに依存する処理を中継するオブジェクト</param>
+		//! @author $author$
+		//------------------------------------------------------------------------------------//
+		public $class$(
+			$modelcontainer$ container,
+			IWpfUiActions uiActions)
+			: base(container, uiActions)
+		{
+		}
+		$end$]]>
+      </Code>
+    </Snippet>
+  </CodeSnippet>
+</CodeSnippets>

--- a/projects/LibSnippet/source.extension.vsixmanifest
+++ b/projects/LibSnippet/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="LibSnippet.40bdbfa4-1273-4985-a1fd-10b7d7e26577" Version="3.0.0" Language="en-US" Publisher="ELIONIX" />
+        <Identity Id="LibSnippet.40bdbfa4-1273-4985-a1fd-10b7d7e26577" Version="3.1.0" Language="en-US" Publisher="ELIONIX" />
         <DisplayName>ELIONIX Lib Snippet</DisplayName>
         <Description xml:space="preserve">
 A collection of snippets to assist in writing using ELIONIX libraries.</Description>


### PR DESCRIPTION
以下のコードスニペットを追加しました。全部csコード用です。

- dcattr （DataContract & Serializable属性追加）
- disposablebor （DisposeManagedResources & DisposeUnmanagedResourcesのoverride追加）
- propdpe （依存関係プロパティ）
- propdpec （依存関係プロパティ & コールバック）
- propae （添付プロパティ）
- propaeb （添付ビヘイビア）
- vmctorwpf （ViewModelのコンストラクタ）

実装するときに他からコピーすることの多いものを中心に追加しました。

また、3.0実装時に、スニペットのローカライズの方法が分からず、とりあえずToolTip等も英語で記述したのですが、結局スニペットで追加する中身のコメントが日本語だったりするので、ToolTip等も全部日本語に変更しました。
ローカライズの方法が分かったらその時はデフォを英語に戻します。