### PR TITLE
Develop3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,3 +312,19 @@ UTUtilityという文字だけのコードを生成する。
 また、コードの生成と同時に、"ELIONIX.Lib.Tests.Core"のusing宣言と、ELIONIX.Lib.Tests.dll及びELIONIX.Lib.Tests.Core.dllの参照が追加される。
 
 usingと参照の追加動作の方がメインのスニペット。
+
+#### ututiodirectory, ututiodirectoryasync
+
+ファイルの入出力が関わる単体テストを書く場面において、UTUtility.RunIOTestWithAppropriateDirectoryやUTUtility.RunIOTestWithAppropriateDirectoryAsyncを使いたいときに使用するスニペット。  
+
+ututiodirectoryは以下の雛形を生成する。
+
+```cs
+UTUtility.RunIOTestWithAppropriateDirectory(
+	GetType(),
+	directory => {
+		
+	});
+```
+
+また、コードの生成と同時に、"ELIONIX.Lib.Tests.Core"のusing宣言と、ELIONIX.Lib.Tests.dll及びELIONIX.Lib.Tests.Core.dllの参照が追加される。

--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ protected static void OnHogePropertyChanged(DependencyObject d, DependencyProper
 #### mstestclass
 
 MSTestでのUTクラスを作成する時に使用するスニペット。  
-以下の雛形を作成する。
+以下の雛形を生成する。
 
 ```cs
 [TestClass()]
@@ -323,6 +323,35 @@ public class HogeTests
 |箇所|初期文字列|説明|
 |:--|:--|:--|
 |対象クラス|Hoge|UT対象のクラス名を入力し、UT用のクラスの名前を完成させる。|
+
+また、コードの生成と同時に、"Microsoft.VisualStudio.TestTools.UnitTesting"のusing宣言が追加される。  
+dll参照はnuget packageのため追加しない。
+
+#### mstestfunction, mstestfunctionasync
+
+MSTestでのUT関数を作成する時に使用するスニペット。
+
+mstestfunctionとmstestfunctionasyncはそれぞれ以下の雛形を生成する。
+
+```cs
+[TestMethod()]
+public void TestHoge()
+{
+
+}
+
+[TestMethod()]
+public async Task TestHogeAsync()
+{
+
+}
+```
+
+この雛形において、変更出来る箇所は以下の通り。
+
+|箇所|初期文字列|説明|
+|:--|:--|:--|
+|対象関数|Hoge|UT対象の関数名を入力し、UT用の関数名を完成させる。|
 
 また、コードの生成と同時に、"Microsoft.VisualStudio.TestTools.UnitTesting"のusing宣言が追加される。  
 dll参照はnuget packageのため追加しない。

--- a/README.md
+++ b/README.md
@@ -6,6 +6,24 @@
 
 ### enum, EnumHelper関連
 
+#### enumhelper
+
+EnumHelperを使うときに使用するスニペット。
+以下の雛形が生成される。
+
+```cs
+EnumHelper<HogeKind>
+```
+
+この雛形において、変更出来る箇所は以下の通り。
+
+|箇所|初期文字列|説明|
+|:--|:--|:--|
+|列挙型|HogeKind|列挙してforeachを行いたい列挙型を記述する。|
+また、コードの生成と同時に、"ELIONIX.Lib.Enums"のusing宣言と、ELIONIX.Lib.dllの参照が追加される。
+
+usingと参照の追加動作の方がメインのスニペット。
+
 #### enumforeach
 
 EnumHelper.ForEachを記述したいときに使用するスニペット。  

--- a/README.md
+++ b/README.md
@@ -303,3 +303,12 @@ protected static void OnHogePropertyChanged(DependencyObject d, DependencyProper
 |author|ELIONIX|自分の名前を記述する|
 
 また、コードの生成と同時に、"System.Windows"のusing宣言と、WindowsBase.dllの参照が追加される。
+
+### 単体テスト関連
+
+#### utut
+
+UTUtilityという文字だけのコードを生成する。  
+また、コードの生成と同時に、"ELIONIX.Lib.Tests.Core"のusing宣言と、ELIONIX.Lib.Tests.dll及びELIONIX.Lib.Tests.Core.dllの参照が追加される。
+
+usingと参照の追加動作の方がメインのスニペット。

--- a/README.md
+++ b/README.md
@@ -56,6 +56,20 @@ Lib.BindableBaseやLib.Data.CloneableDataBaseの派生クラスなど、シリ�
 
 また、コードの生成と同時に、"System.Runtime.Serialization"のusing宣言と、System.Runtime.Serialization.dllの参照が追加される。
 
+#### cloneabledb, fileabledb
+
+```CloneableDataBase<T>```、または、```FileableDataBase<T>```を継承するクラスの定義において、親クラスを指定する部分のコードを生成する。  
+名前は、CLONEABLEDataBase、及び、FILEABLEDataBaseである。  
+
+例えばcloneabledbの場合、以下のコードが生成される。
+
+```cs
+CloneableDataBase<Hoge>
+```
+
+Hogeの部分には、自分のクラス名が自動的に挿入される。  
+また、コードの生成と同時に、"ELIONIX.Lib.Data"のusing宣言と、ELIONIX.Lib.dllの参照が追加される。
+
 ### classの初期化・終了系
 
 #### vmctorwpf

--- a/README.md
+++ b/README.md
@@ -306,6 +306,27 @@ protected static void OnHogePropertyChanged(DependencyObject d, DependencyProper
 
 ### 単体テスト関連
 
+#### mstestclass
+
+MSTestでのUTクラスを作成する時に使用するスニペット。  
+以下の雛形を作成する。
+
+```cs
+[TestClass()]
+public class HogeTests
+{
+}
+```
+
+この雛形において、変更出来る箇所は以下の通り。
+
+|箇所|初期文字列|説明|
+|:--|:--|:--|
+|対象クラス|Hoge|UT対象のクラス名を入力し、UT用のクラスの名前を完成させる。|
+
+また、コードの生成と同時に、"Microsoft.VisualStudio.TestTools.UnitTesting"のusing宣言が追加される。  
+dll参照はnuget packageのため追加しない。
+
 #### utut
 
 UTUtilityという文字だけのコードを生成する。  

--- a/README.md
+++ b/README.md
@@ -4,6 +4,27 @@
 
 ## C#のLib用のスニペット
 
+### enum, EnumHelper関連
+
+#### enumforeach
+
+EnumHelper.ForEachを記述したいときに使用するスニペット。  
+以下の雛形が生成される。
+
+```cs
+EnumHelper<HogeKind>.ForEach(kind => {
+
+});
+```
+
+この雛形において、変更出来る箇所は以下の通り。
+
+|箇所|初期文字列|説明|
+|:--|:--|:--|
+|列挙型|HogeKind|列挙してforeachを行いたい列挙型を記述する。|
+
+また、コードの生成と同時に、"ELIONIX.Lib.Enums"のusing宣言と、ELIONIX.Lib.dllの参照が追加される。
+
 ### データクラス関連
 
 #### propbb, propbbd

--- a/projects/LibSnippet/LibSnippet.csproj
+++ b/projects/LibSnippet/LibSnippet.csproj
@@ -105,6 +105,10 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
+    <Content Include="Snippets\CSharp\ELIONIX.Lib\utut.snippet">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>

--- a/projects/LibSnippet/LibSnippet.csproj
+++ b/projects/LibSnippet/LibSnippet.csproj
@@ -109,6 +109,14 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
+    <Content Include="Snippets\CSharp\ELIONIX.Lib\ututiodirectory.snippet">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
+    <Content Include="Snippets\CSharp\ELIONIX.Lib\ututiodirectoryasync.snippet">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>

--- a/projects/LibSnippet/LibSnippet.csproj
+++ b/projects/LibSnippet/LibSnippet.csproj
@@ -117,6 +117,10 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
+    <Content Include="Snippets\CSharp\ELIONIX.Lib\mstestclass.snippet">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>

--- a/projects/LibSnippet/LibSnippet.csproj
+++ b/projects/LibSnippet/LibSnippet.csproj
@@ -133,6 +133,10 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
+    <Content Include="Snippets\CSharp\ELIONIX.Lib\enumhelper.snippet">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>

--- a/projects/LibSnippet/LibSnippet.csproj
+++ b/projects/LibSnippet/LibSnippet.csproj
@@ -121,6 +121,14 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
+    <Content Include="Snippets\CSharp\ELIONIX.Lib\mstestfunction.snippet">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
+    <Content Include="Snippets\CSharp\ELIONIX.Lib\mstestfunctionasync.snippet">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>

--- a/projects/LibSnippet/LibSnippet.csproj
+++ b/projects/LibSnippet/LibSnippet.csproj
@@ -129,6 +129,10 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
+    <Content Include="Snippets\CSharp\ELIONIX.Lib\enumforeach.snippet">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>

--- a/projects/LibSnippet/LibSnippet.csproj
+++ b/projects/LibSnippet/LibSnippet.csproj
@@ -97,6 +97,14 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
+    <Content Include="Snippets\CSharp\ELIONIX.Lib\cloneabledb.snippet">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
+    <Content Include="Snippets\CSharp\ELIONIX.Lib\fileabledb.snippet">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>

--- a/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/cloneabledb.snippet
+++ b/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/cloneabledb.snippet
@@ -29,7 +29,7 @@
         </Literal>
       </Declarations>
       <Code Language="csharp">
-        <![CDATA[CloneableDataBase<$class$>]]>
+        <![CDATA[CloneableDataBase<$class$>$end$]]>
       </Code>
     </Snippet>
   </CodeSnippet>

--- a/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/cloneabledb.snippet
+++ b/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/cloneabledb.snippet
@@ -1,0 +1,36 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<CodeSnippets xmlns="http://schemas.microsoft.com/VisualStudio/2005/CodeSnippet">
+  <CodeSnippet Format="1.0.0">
+    <Header>
+      <Title>cloneabledb</Title>
+      <Shortcut>cloneabledb</Shortcut>
+      <Description>基底クラスとしてCloneableDataBase{T}を指定する記述を生成する</Description>
+      <Author>SAITO Takamasa</Author>
+      <SnippetTypes>
+        <SnippetType>Expansion</SnippetType>
+      </SnippetTypes>
+    </Header>
+    <Snippet>
+      <References>
+        <Reference>
+          <Assembly>ELIONIX.Lib.dll</Assembly>
+        </Reference>
+      </References>
+      <Imports>
+        <Import>
+          <Namespace>ELIONIX.Lib.Data</Namespace>
+        </Import>
+      </Imports>
+      <Declarations>
+        <Literal Editable="false">
+          <ID>class</ID>
+          <Function>ClassName()</Function>
+          <ToolTip>自クラスの名前</ToolTip>
+        </Literal>
+      </Declarations>
+      <Code Language="csharp">
+        <![CDATA[CloneableDataBase<$class$>]]>
+      </Code>
+    </Snippet>
+  </CodeSnippet>
+</CodeSnippets>

--- a/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/enumforeach.snippet
+++ b/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/enumforeach.snippet
@@ -1,0 +1,38 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<CodeSnippets xmlns="http://schemas.microsoft.com/VisualStudio/2005/CodeSnippet">
+  <CodeSnippet Format="1.0.0">
+    <Header>
+      <Title>enumforeach</Title>
+      <Shortcut>enumforeach</Shortcut>
+      <Description>EnumHelper.ForEachの雛形を生成する。</Description>
+      <Author>SAITO Takamasa</Author>
+      <SnippetTypes>
+        <SnippetType>Expansion</SnippetType>
+      </SnippetTypes>
+    </Header>
+    <Snippet>
+      <References>
+        <Reference>
+          <Assembly>ELIONIX.Lib.dll</Assembly>
+        </Reference>
+      </References>
+      <Imports>
+        <Import>
+          <Namespace>ELIONIX.Lib.Enums</Namespace>
+        </Import>
+      </Imports>
+      <Declarations>
+        <Literal>
+          <ID>enum</ID>
+          <ToolTip>enum型の名前</ToolTip>
+          <Default>HogeKind</Default>
+        </Literal>
+      </Declarations>
+      <Code Language="csharp">
+        <![CDATA[EnumHelper<$enum$>.ForEach(kind => {
+				$end$
+			});]]>
+      </Code>
+    </Snippet>
+  </CodeSnippet>
+</CodeSnippets>

--- a/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/enumhelper.snippet
+++ b/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/enumhelper.snippet
@@ -1,0 +1,36 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<CodeSnippets xmlns="http://schemas.microsoft.com/VisualStudio/2005/CodeSnippet">
+  <CodeSnippet Format="1.0.0">
+    <Header>
+      <Title>enumhelper</Title>
+      <Shortcut>enumhelper</Shortcut>
+      <Description>EnumHelperの雛形を生成する。</Description>
+      <Author>SAITO Takamasa</Author>
+      <SnippetTypes>
+        <SnippetType>Expansion</SnippetType>
+      </SnippetTypes>
+    </Header>
+    <Snippet>
+      <References>
+        <Reference>
+          <Assembly>ELIONIX.Lib.dll</Assembly>
+        </Reference>
+      </References>
+      <Imports>
+        <Import>
+          <Namespace>ELIONIX.Lib.Enums</Namespace>
+        </Import>
+      </Imports>
+      <Declarations>
+        <Literal>
+          <ID>enum</ID>
+          <ToolTip>enum型の名前</ToolTip>
+          <Default>HogeKind</Default>
+        </Literal>
+      </Declarations>
+      <Code Language="csharp">
+        <![CDATA[EnumHelper<$enum$>$end$]]>
+      </Code>
+    </Snippet>
+  </CodeSnippet>
+</CodeSnippets>

--- a/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/fileabledb.snippet
+++ b/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/fileabledb.snippet
@@ -1,0 +1,36 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<CodeSnippets xmlns="http://schemas.microsoft.com/VisualStudio/2005/CodeSnippet">
+  <CodeSnippet Format="1.0.0">
+    <Header>
+      <Title>fileabledb</Title>
+      <Shortcut>fileabledb</Shortcut>
+      <Description>基底クラスとしてFileableDataBase{T}を指定する記述を生成する</Description>
+      <Author>SAITO Takamasa</Author>
+      <SnippetTypes>
+        <SnippetType>Expansion</SnippetType>
+      </SnippetTypes>
+    </Header>
+    <Snippet>
+      <References>
+        <Reference>
+          <Assembly>ELIONIX.Lib.dll</Assembly>
+        </Reference>
+      </References>
+      <Imports>
+        <Import>
+          <Namespace>ELIONIX.Lib.Data</Namespace>
+        </Import>
+      </Imports>
+      <Declarations>
+        <Literal Editable="false">
+          <ID>class</ID>
+          <Function>ClassName()</Function>
+          <ToolTip>自クラスの名前</ToolTip>
+        </Literal>
+      </Declarations>
+      <Code Language="csharp">
+        <![CDATA[FileableDataBase<$class$>]]>
+      </Code>
+    </Snippet>
+  </CodeSnippet>
+</CodeSnippets>

--- a/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/mstestclass.snippet
+++ b/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/mstestclass.snippet
@@ -1,0 +1,35 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<CodeSnippets xmlns="http://schemas.microsoft.com/VisualStudio/2005/CodeSnippet">
+  <CodeSnippet Format="1.0.0">
+    <Header>
+      <Title>mstestclass</Title>
+      <Shortcut>mstestclass</Shortcut>
+      <Description>MSTestのUTクラスの雛形を生成する。</Description>
+      <Author>SAITO Takamasa</Author>
+      <SnippetTypes>
+        <SnippetType>Expansion</SnippetType>
+      </SnippetTypes>
+    </Header>
+    <Snippet>
+      <Imports>
+        <Import>
+          <Namespace>Microsoft.VisualStudio.TestTools.UnitTesting</Namespace>
+        </Import>
+      </Imports>
+      <Declarations>
+        <Literal>
+          <ID>class</ID>
+          <ToolTip>クラスの名前</ToolTip>
+          <Default>Hoge</Default>
+        </Literal>
+      </Declarations>
+      <Code Language="csharp">
+        <![CDATA[[TestClass()]
+	public class $class$Tests
+	{
+		$end$
+	}]]>
+      </Code>
+    </Snippet>
+  </CodeSnippet>
+</CodeSnippets>

--- a/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/mstestfunction.snippet
+++ b/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/mstestfunction.snippet
@@ -2,9 +2,9 @@
 <CodeSnippets xmlns="http://schemas.microsoft.com/VisualStudio/2005/CodeSnippet">
   <CodeSnippet Format="1.0.0">
     <Header>
-      <Title>mstestclass</Title>
-      <Shortcut>mstestclass</Shortcut>
-      <Description>MSTestのUTクラスの雛形を生成する。</Description>
+      <Title>mstestfunction</Title>
+      <Shortcut>mstestfunction</Shortcut>
+      <Description>MSTestのUT関数の雛形を生成する。</Description>
       <Author>SAITO Takamasa</Author>
       <SnippetTypes>
         <SnippetType>Expansion</SnippetType>
@@ -18,17 +18,17 @@
       </Imports>
       <Declarations>
         <Literal>
-          <ID>class</ID>
-          <ToolTip>UT対象のクラスの名前</ToolTip>
+          <ID>function</ID>
+          <ToolTip>UT対象の関数の名前</ToolTip>
           <Default>Hoge</Default>
         </Literal>
       </Declarations>
       <Code Language="csharp">
-        <![CDATA[[TestClass()]
-	public class $class$Tests
-	{
-		$end$
-	}]]>
+        <![CDATA[[TestMethod()]
+		public void Test$function$()
+		{
+			$end$
+		}]]>
       </Code>
     </Snippet>
   </CodeSnippet>

--- a/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/mstestfunctionasync.snippet
+++ b/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/mstestfunctionasync.snippet
@@ -2,9 +2,9 @@
 <CodeSnippets xmlns="http://schemas.microsoft.com/VisualStudio/2005/CodeSnippet">
   <CodeSnippet Format="1.0.0">
     <Header>
-      <Title>mstestclass</Title>
-      <Shortcut>mstestclass</Shortcut>
-      <Description>MSTestのUTクラスの雛形を生成する。</Description>
+      <Title>mstestfunctionasync</Title>
+      <Shortcut>mstestfunctionasync</Shortcut>
+      <Description>MSTestのUT関数の雛形を生成する。（非同期版）</Description>
       <Author>SAITO Takamasa</Author>
       <SnippetTypes>
         <SnippetType>Expansion</SnippetType>
@@ -15,20 +15,23 @@
         <Import>
           <Namespace>Microsoft.VisualStudio.TestTools.UnitTesting</Namespace>
         </Import>
+        <Import>
+          <Namespace>System.Threading.Tasks</Namespace>
+        </Import>
       </Imports>
       <Declarations>
         <Literal>
-          <ID>class</ID>
-          <ToolTip>UT対象のクラスの名前</ToolTip>
+          <ID>function</ID>
+          <ToolTip>UT対象の関数の名前</ToolTip>
           <Default>Hoge</Default>
         </Literal>
       </Declarations>
       <Code Language="csharp">
-        <![CDATA[[TestClass()]
-	public class $class$Tests
-	{
-		$end$
-	}]]>
+        <![CDATA[[TestMethod()]
+		public async Task Test$function$Async()
+		{
+			$end$
+		}]]>
       </Code>
     </Snippet>
   </CodeSnippet>

--- a/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/utut.snippet
+++ b/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/utut.snippet
@@ -2,9 +2,9 @@
 <CodeSnippets xmlns="http://schemas.microsoft.com/VisualStudio/2005/CodeSnippet">
   <CodeSnippet Format="1.0.0">
     <Header>
-      <Title>fileabledb</Title>
-      <Shortcut>fileabledb</Shortcut>
-      <Description>基底クラスとしてFileableDataBase{T}を指定する記述を生成する</Description>
+      <Title>utut</Title>
+      <Shortcut>utut</Shortcut>
+      <Description>UTUtilityの呼び出し</Description>
       <Author>SAITO Takamasa</Author>
       <SnippetTypes>
         <SnippetType>Expansion</SnippetType>
@@ -13,23 +13,19 @@
     <Snippet>
       <References>
         <Reference>
-          <Assembly>ELIONIX.Lib.dll</Assembly>
+          <Assembly>ELIONIX.Lib.Tests.dll</Assembly>
+        </Reference>
+        <Reference>
+          <Assembly>ELIONIX.Lib.Tests.Core.dll</Assembly>
         </Reference>
       </References>
       <Imports>
         <Import>
-          <Namespace>ELIONIX.Lib.Data</Namespace>
+          <Namespace>ELIONIX.Lib.Tests.Core</Namespace>
         </Import>
       </Imports>
-      <Declarations>
-        <Literal Editable="false">
-          <ID>class</ID>
-          <Function>ClassName()</Function>
-          <ToolTip>自クラスの名前</ToolTip>
-        </Literal>
-      </Declarations>
       <Code Language="csharp">
-        <![CDATA[FileableDataBase<$class$>$end$]]>
+        <![CDATA[UTUtility$end$]]>
       </Code>
     </Snippet>
   </CodeSnippet>

--- a/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/ututiodirectory.snippet
+++ b/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/ututiodirectory.snippet
@@ -1,0 +1,36 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<CodeSnippets xmlns="http://schemas.microsoft.com/VisualStudio/2005/CodeSnippet">
+  <CodeSnippet Format="1.0.0">
+    <Header>
+      <Title>ututiodirectory</Title>
+      <Shortcut>ututiodirectory</Shortcut>
+      <Description>UTUtility.RunIOTestWithAppropriateDirectoryの雛形を生成する。</Description>
+      <Author>SAITO Takamasa</Author>
+      <SnippetTypes>
+        <SnippetType>Expansion</SnippetType>
+      </SnippetTypes>
+    </Header>
+    <Snippet>
+      <References>
+        <Reference>
+          <Assembly>ELIONIX.Lib.Tests.dll</Assembly>
+        </Reference>
+        <Reference>
+          <Assembly>ELIONIX.Lib.Tests.Core.dll</Assembly>
+        </Reference>
+      </References>
+      <Imports>
+        <Import>
+          <Namespace>ELIONIX.Lib.Tests.Core</Namespace>
+        </Import>
+      </Imports>
+      <Code Language="csharp">
+        <![CDATA[UTUtility.RunIOTestWithAppropriateDirectory(
+				GetType(),
+				directory => {
+					$end$
+				});]]>
+      </Code>
+    </Snippet>
+  </CodeSnippet>
+</CodeSnippets>

--- a/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/ututiodirectoryasync.snippet
+++ b/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/ututiodirectoryasync.snippet
@@ -1,0 +1,36 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<CodeSnippets xmlns="http://schemas.microsoft.com/VisualStudio/2005/CodeSnippet">
+  <CodeSnippet Format="1.0.0">
+    <Header>
+      <Title>ututiodirectoryasync</Title>
+      <Shortcut>ututiodirectoryasync</Shortcut>
+      <Description>UTUtility.RunIOTestWithAppropriateDirectoryの雛形を生成する。</Description>
+      <Author>SAITO Takamasa</Author>
+      <SnippetTypes>
+        <SnippetType>Expansion</SnippetType>
+      </SnippetTypes>
+    </Header>
+    <Snippet>
+      <References>
+        <Reference>
+          <Assembly>ELIONIX.Lib.Tests.dll</Assembly>
+        </Reference>
+        <Reference>
+          <Assembly>ELIONIX.Lib.Tests.Core.dll</Assembly>
+        </Reference>
+      </References>
+      <Imports>
+        <Import>
+          <Namespace>ELIONIX.Lib.Tests.Core</Namespace>
+        </Import>
+      </Imports>
+      <Code Language="csharp">
+        <![CDATA[await UTUtility.RunIOTestWithAppropriateDirectoryAsync(
+				GetType(),
+				async directory => {
+					$end$
+				});]]>
+      </Code>
+    </Snippet>
+  </CodeSnippet>
+</CodeSnippets>


### PR DESCRIPTION
以下のスニペットを追加しました。

- cloneabledb
- fileabledb
- utut
- ututiodirectory
- ututiodirectoryasync
- mstestclass
- mstestfunction
- mstestfunctionasync
- enumforeach
- enumhelper

ようは、CloneableDataBase、FileableDataBase、UTUtility、EnumHelperを使おうとしたときに、usingがされてないことが多くて面倒なので、コードとusingの追加をまとめてやってしまえというスニペットです。