### PR TITLE
Develop3.3

### DIFF
--- a/projects/LibSnippet/LibSnippet.csproj
+++ b/projects/LibSnippet/LibSnippet.csproj
@@ -137,6 +137,10 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
+    <Content Include="Snippets\CSharp\ELIONIX.Lib\ututdataclass.snippet">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>

--- a/projects/LibSnippet/LibSnippet.csproj
+++ b/projects/LibSnippet/LibSnippet.csproj
@@ -93,6 +93,10 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
+    <Content Include="Snippets\CSharp\ELIONIX.Lib\ututenumtodisplayname.snippet">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
     <Content Include="Snippets\CSharp\ELIONIX.Lib\vmctorwpf.snippet">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>

--- a/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/ututdataclass.snippet
+++ b/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/ututdataclass.snippet
@@ -1,0 +1,41 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<CodeSnippets xmlns="http://schemas.microsoft.com/VisualStudio/2005/CodeSnippet">
+  <CodeSnippet Format="1.0.0">
+    <Header>
+      <Title>ututdataclass</Title>
+      <Shortcut>ututdataclass</Shortcut>
+      <Description>データクラスに対する初期化とシリアライズ属性のUTを生成</Description>
+      <Author>SAITO Takamasa</Author>
+      <SnippetTypes>
+        <SnippetType>Expansion</SnippetType>
+      </SnippetTypes>
+    </Header>
+    <Snippet>
+      <References>
+        <Reference>
+          <Assembly>ELIONIX.Lib.Tests.dll</Assembly>
+        </Reference>
+        <Reference>
+          <Assembly>ELIONIX.Lib.Tests.Core.dll</Assembly>
+        </Reference>
+      </References>
+      <Imports>
+        <Import>
+          <Namespace>ELIONIX.Lib.Tests.Core</Namespace>
+        </Import>
+      </Imports>
+      <Declarations>
+        <Literal>
+          <ID>class</ID>
+          <ToolTip>データクラスの型名</ToolTip>
+          <Default>Hoge</Default>
+        </Literal>
+      </Declarations>
+      <Code Language="csharp">
+        <![CDATA[var obj = new $class$();
+			UTUtility.CheckClassAllPropertiesInitialization(obj);
+			UTUtility.CheckClassAttributeForSerialize(obj);$end$]]>
+      </Code>
+    </Snippet>
+  </CodeSnippet>
+</CodeSnippets>

--- a/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/ututenumtodisplayname.snippet
+++ b/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/ututenumtodisplayname.snippet
@@ -1,0 +1,39 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<CodeSnippets xmlns="http://schemas.microsoft.com/VisualStudio/2005/CodeSnippet">
+  <CodeSnippet Format="1.0.0">
+    <Header>
+      <Title>ututenumtodisplayname</Title>
+      <Shortcut>ututenumtodisplayname</Shortcut>
+      <Description>enumのToDisplayName関数に対するUT記述を生成する</Description>
+      <Author>SAITO Takamasa</Author>
+      <SnippetTypes>
+        <SnippetType>Expansion</SnippetType>
+      </SnippetTypes>
+    </Header>
+    <Snippet>
+      <References>
+        <Reference>
+          <Assembly>ELIONIX.Lib.Tests.dll</Assembly>
+        </Reference>
+        <Reference>
+          <Assembly>ELIONIX.Lib.Tests.Core.dll</Assembly>
+        </Reference>
+      </References>
+      <Imports>
+        <Import>
+          <Namespace>ELIONIX.Lib.Tests.Core</Namespace>
+        </Import>
+      </Imports>
+      <Declarations>
+        <Literal>
+          <ID>enum</ID>
+          <ToolTip>enum型の名前</ToolTip>
+          <Default>HogeKind</Default>
+        </Literal>
+      </Declarations>
+      <Code Language="csharp">
+        <![CDATA[UTUtility.TestEnumToDisplayName<$enum$>();$end$]]>
+      </Code>
+    </Snippet>
+  </CodeSnippet>
+</CodeSnippets>

--- a/projects/LibSnippet/source.extension.vsixmanifest
+++ b/projects/LibSnippet/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="LibSnippet.40bdbfa4-1273-4985-a1fd-10b7d7e26577" Version="3.3.0" Language="en-US" Publisher="ELIONIX" />
+        <Identity Id="LibSnippet.40bdbfa4-1273-4985-a1fd-10b7d7e26577" Version="3.3.1" Language="en-US" Publisher="ELIONIX" />
         <DisplayName>ELIONIX Lib Snippet</DisplayName>
         <Description xml:space="preserve">
 A collection of snippets to assist in writing using ELIONIX libraries.</Description>

--- a/projects/LibSnippet/source.extension.vsixmanifest
+++ b/projects/LibSnippet/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="LibSnippet.40bdbfa4-1273-4985-a1fd-10b7d7e26577" Version="3.2.0" Language="en-US" Publisher="ELIONIX" />
+        <Identity Id="LibSnippet.40bdbfa4-1273-4985-a1fd-10b7d7e26577" Version="3.3.0" Language="en-US" Publisher="ELIONIX" />
         <DisplayName>ELIONIX Lib Snippet</DisplayName>
         <Description xml:space="preserve">
 A collection of snippets to assist in writing using ELIONIX libraries.</Description>


### PR DESCRIPTION
## 関連プルリクエスト
ELIONIX/LibCS#2508

## 変更内容
UTでよく記述する、

- enumのToDisplayName関数に対する網羅チェックのUT
- データクラスに対する、初期化とDataMember属性チェックのUT

に対するスニペットを追加しました。
3.3.0ではなく3.3.1になっているのは、作成中のデバッグ上の都合です。