### PR TITLE
UT関連ライブラリの名前空間変更に合わせてreferenceとimportを変更

### DIFF
--- a/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/utut.snippet
+++ b/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/utut.snippet
@@ -13,15 +13,12 @@
     <Snippet>
       <References>
         <Reference>
-          <Assembly>ELIONIX.Lib.Tests.dll</Assembly>
-        </Reference>
-        <Reference>
-          <Assembly>ELIONIX.Lib.Tests.Core.dll</Assembly>
+          <Assembly>ELIONIX.Lib.UT.dll</Assembly>
         </Reference>
       </References>
       <Imports>
         <Import>
-          <Namespace>ELIONIX.Lib.Tests.Core</Namespace>
+          <Namespace>ELIONIX.Lib.UT</Namespace>
         </Import>
       </Imports>
       <Code Language="csharp">

--- a/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/ututdataclass.snippet
+++ b/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/ututdataclass.snippet
@@ -13,15 +13,12 @@
     <Snippet>
       <References>
         <Reference>
-          <Assembly>ELIONIX.Lib.Tests.dll</Assembly>
-        </Reference>
-        <Reference>
-          <Assembly>ELIONIX.Lib.Tests.Core.dll</Assembly>
+          <Assembly>ELIONIX.Lib.UT.dll</Assembly>
         </Reference>
       </References>
       <Imports>
         <Import>
-          <Namespace>ELIONIX.Lib.Tests.Core</Namespace>
+          <Namespace>ELIONIX.Lib.UT</Namespace>
         </Import>
       </Imports>
       <Declarations>

--- a/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/ututenumtodisplayname.snippet
+++ b/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/ututenumtodisplayname.snippet
@@ -13,15 +13,12 @@
     <Snippet>
       <References>
         <Reference>
-          <Assembly>ELIONIX.Lib.Tests.dll</Assembly>
-        </Reference>
-        <Reference>
-          <Assembly>ELIONIX.Lib.Tests.Core.dll</Assembly>
+          <Assembly>ELIONIX.Lib.UT.dll</Assembly>
         </Reference>
       </References>
       <Imports>
         <Import>
-          <Namespace>ELIONIX.Lib.Tests.Core</Namespace>
+          <Namespace>ELIONIX.Lib.UT</Namespace>
         </Import>
       </Imports>
       <Declarations>

--- a/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/ututiodirectory.snippet
+++ b/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/ututiodirectory.snippet
@@ -13,15 +13,12 @@
     <Snippet>
       <References>
         <Reference>
-          <Assembly>ELIONIX.Lib.Tests.dll</Assembly>
-        </Reference>
-        <Reference>
-          <Assembly>ELIONIX.Lib.Tests.Core.dll</Assembly>
+          <Assembly>ELIONIX.Lib.UT.dll</Assembly>
         </Reference>
       </References>
       <Imports>
         <Import>
-          <Namespace>ELIONIX.Lib.Tests.Core</Namespace>
+          <Namespace>ELIONIX.Lib.UT</Namespace>
         </Import>
       </Imports>
       <Code Language="csharp">

--- a/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/ututiodirectoryasync.snippet
+++ b/projects/LibSnippet/Snippets/CSharp/ELIONIX.Lib/ututiodirectoryasync.snippet
@@ -13,15 +13,12 @@
     <Snippet>
       <References>
         <Reference>
-          <Assembly>ELIONIX.Lib.Tests.dll</Assembly>
-        </Reference>
-        <Reference>
-          <Assembly>ELIONIX.Lib.Tests.Core.dll</Assembly>
+          <Assembly>ELIONIX.Lib.UT.dll</Assembly>
         </Reference>
       </References>
       <Imports>
         <Import>
-          <Namespace>ELIONIX.Lib.Tests.Core</Namespace>
+          <Namespace>ELIONIX.Lib.UT</Namespace>
         </Import>
       </Imports>
       <Code Language="csharp">

--- a/projects/LibSnippet/source.extension.vsixmanifest
+++ b/projects/LibSnippet/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="LibSnippet.40bdbfa4-1273-4985-a1fd-10b7d7e26577" Version="3.3.2" Language="en-US" Publisher="ELIONIX" />
+        <Identity Id="LibSnippet.40bdbfa4-1273-4985-a1fd-10b7d7e26577" Version="3.4.0" Language="en-US" Publisher="ELIONIX" />
         <DisplayName>ELIONIX Lib Snippet</DisplayName>
         <Description xml:space="preserve">
 A collection of snippets to assist in writing using ELIONIX libraries.</Description>


### PR DESCRIPTION
表題の通りです。
Lib.Tests.dll、及び、Lib.Tests.Core.dll を参照するようにしていたのを、 Lib.UT.dll を参照するようにし、追加するusingも Lib.UT に変更しました。